### PR TITLE
add integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,3 +17,6 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make
+      - run: make int-test
+        env:
+          MAGIC_SEAWEED_API_KEY: ${{ secrets.MAGIC_SEAWEED_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make
+      - run: make int-test
+        env:
+          MAGIC_SEAWEED_API_KEY: ${{ secrets.MAGIC_SEAWEED_API_KEY }}
 
   release:
     needs: test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE=./
-VERSION=1.0.0
+VERSION=0.6.0
 
 .DEFAULT_GOAL := test
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ test: vet test-fmt
 	go test -v -coverprofile=coverage.out -race $(SOURCE)
 .PHONY: test
 
+int-test: vet test-fmt
+	go test -v -race ./internal/integrationtest
+.PHONY: int-test
+
 vet:
 	go vet $(SOURCE)
 .PHONY: vet

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE=./...
+SOURCE=./
 VERSION=0.5.0
 
 .DEFAULT_GOAL := test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE=./
-VERSION=0.5.0
+VERSION=1.0.0
 
 .DEFAULT_GOAL := test
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/mdb/seaweed/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/mdb/seaweed/actions/workflows/ci.yaml)
+[![CI](https://github.com/mdb/seaweed/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/mdb/seaweed/actions/workflows/ci.yaml) [![PkgGoDev](https://pkg.go.dev/badge/github.com/mdb/seaweed)](https://pkg.go.dev/github.com/mdb/seaweed)
 
 # seaweed
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Use a customized client:
 
 ```go
 client := seaweed.Client{
+  BaseURL:    "https://magicseaweed.com",
   APIKey:     "YOUR_KEY",
   HTTPClient: &http.Client{},           // *http.Client
   Logger:     logrus.New(logging.INFO), // *logrus.Logger

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/mdb/seaweed/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/mdb/seaweed/actions/workflows/ci.yaml) [![PkgGoDev](https://pkg.go.dev/badge/github.com/mdb/seaweed)](https://pkg.go.dev/github.com/mdb/seaweed)
+[![CI](https://github.com/mdb/seaweed/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/mdb/seaweed/actions/workflows/ci.yaml) [![PkgGoDev](https://pkg.go.dev/badge/github.com/mdb/seaweed)](https://pkg.go.dev/github.com/mdb/seaweed) [![Go Report Card](https://goreportcard.com/badge/github.com/mdb/seaweed)](https://goreportcard.com/report/github.com/mdb/seaweed)
 
 # seaweed
 

--- a/client.go
+++ b/client.go
@@ -116,7 +116,7 @@ func (c *Client) Weekend(spot string) ([]Forecast, error) {
 }
 
 func (c *Client) getForecast(spotID string) ([]Forecast, error) {
-	url := fmt.Sprintf("https://magicseaweed.com/api/%s/forecast/?spot_id=%s", c.APIKey, spotID)
+	url := fmt.Sprintf("http://magicseaweed.com/api/%s/forecast/?spot_id=%s", c.APIKey, spotID)
 	forecasts := []Forecast{}
 	body, err := c.get(url)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ func (RealClock) Now() time.Time {
 
 // Client represents a seaweed API client
 type Client struct {
+	BaseURL    string
 	APIKey     string
 	HTTPClient *http.Client
 	Logger     *logrus.Logger
@@ -37,6 +38,7 @@ type Client struct {
 // NewClient takes an API key and returns a seaweed API client
 func NewClient(APIKey string) *Client {
 	return &Client{
+		"https://magicseaweed.com",
 		APIKey,
 		&http.Client{},
 		logrus.New(),
@@ -116,7 +118,7 @@ func (c *Client) Weekend(spot string) ([]Forecast, error) {
 }
 
 func (c *Client) getForecast(spotID string) ([]Forecast, error) {
-	url := fmt.Sprintf("http://magicseaweed.com/api/%s/forecast/?spot_id=%s", c.APIKey, spotID)
+	url := fmt.Sprintf("%s/api/%s/forecast/?spot_id=%s", c.BaseURL, c.APIKey, spotID)
 	forecasts := []Forecast{}
 	body, err := c.get(url)
 	if err != nil {
@@ -155,9 +157,10 @@ func (c *Client) get(url string) ([]byte, error) {
 	}
 
 	sanitizedURL := strings.Replace(url, c.APIKey, "<REDACTED>", 1)
+	sanitizedURL = strings.Replace(sanitizedURL, c.BaseURL, "", 1)
 
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("%s returned HTTP status code %d", sanitizedURL, resp.StatusCode)
+		err = fmt.Errorf("GET %s returned HTTP status code %d", sanitizedURL, resp.StatusCode)
 	}
 
 	l := c.Logger.WithFields(

--- a/client.go
+++ b/client.go
@@ -1,3 +1,4 @@
+// Package seaweed provides a Magic Seaweed API client.
 package seaweed
 
 import (
@@ -12,8 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Clock is a clock interface used to report the current time.
-// It exists largely to test the Client#Tomorrow method.
+// Clock is a clock interface used to report the current time such that the
+// Client#Today and Client#Tomorrow methods can return the proper forecasts
+// relative to the current time.
+// It exists largely for testing purposes.
 type Clock interface {
 	Now() time.Time
 }
@@ -28,11 +31,18 @@ func (RealClock) Now() time.Time {
 
 // Client represents a seaweed API client
 type Client struct {
-	BaseURL    string
-	APIKey     string
+	// BaseURL is the targeted Magic Seaweed API base URL, such as https://magicseaweed.com.
+	BaseURL string
+	// APIKey is a Magic Seaweed API key.
+	APIKey string
+	// HTTPClient is a *http.Client.
 	HTTPClient *http.Client
-	Logger     *logrus.Logger
-	clock      Clock
+	// Logger is a *logrus.Logger.
+	Logger *logrus.Logger
+	// clock is a seaweed.Clock used to report the current time/date such that the
+	// Client#Tomorrow and Client#Today methods can return the proper forecasts
+	// relative to the current time.
+	clock Clock
 }
 
 // NewClient takes an API key and returns a seaweed API client

--- a/client.go
+++ b/client.go
@@ -154,11 +154,12 @@ func (c *Client) get(url string) ([]byte, error) {
 		return nil, err
 	}
 
+	sanitizedURL := strings.Replace(url, c.APIKey, "<REDACTED>", 1)
+
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("%s returned HTTP status code %d", url, resp.StatusCode)
+		err = fmt.Errorf("%s returned HTTP status code %d", sanitizedURL, resp.StatusCode)
 	}
 
-	sanitizedURL := strings.Replace(url, c.APIKey, "<REDACTED>", 1)
 	l := c.Logger.WithFields(
 		logrus.Fields{
 			"url":         sanitizedURL,

--- a/client.go
+++ b/client.go
@@ -116,7 +116,7 @@ func (c *Client) Weekend(spot string) ([]Forecast, error) {
 }
 
 func (c *Client) getForecast(spotID string) ([]Forecast, error) {
-	url := fmt.Sprintf("http://magicseaweed.com/api/%s/forecast/?spot_id=%s", c.APIKey, spotID)
+	url := fmt.Sprintf("https://magicseaweed.com/api/%s/forecast/?spot_id=%s", c.APIKey, spotID)
 	forecasts := []Forecast{}
 	body, err := c.get(url)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -158,9 +158,10 @@ func (c *Client) get(url string) ([]byte, error) {
 		err = fmt.Errorf("%s returned HTTP status code %d", url, resp.StatusCode)
 	}
 
+	sanitizedURL := strings.Replace(url, c.APIKey, "<REDACTED>", 1)
 	l := c.Logger.WithFields(
 		logrus.Fields{
-			"url":         url,
+			"url":         sanitizedURL,
 			"http_status": resp.StatusCode,
 			"body":        string(body),
 		})

--- a/client_test.go
+++ b/client_test.go
@@ -61,6 +61,7 @@ func testServerAndClient(code int, body string) (*httptest.Server, *Client) {
 	httpClient := &http.Client{Transport: tr}
 
 	client := &Client{
+		server.URL,
 		"fakeKey",
 		httpClient,
 		logrus.New(),
@@ -103,7 +104,7 @@ func TestForecast(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}, {
 		desc:                "when the response code is OK but the response body specifies an error",
 		body:                errorResp,
@@ -174,7 +175,7 @@ func TestWeekend(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -233,7 +234,7 @@ func TestToday(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -292,7 +293,7 @@ func TestTomorrow(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -103,7 +103,7 @@ func TestForecast(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}, {
 		desc:                "when the response code is OK but the response body specifies an error",
 		body:                errorResp,
@@ -174,7 +174,7 @@ func TestWeekend(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -233,7 +233,7 @@ func TestToday(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -292,7 +292,7 @@ func TestTomorrow(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -103,7 +103,7 @@ func TestForecast(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}, {
 		desc:                "when the response code is OK but the response body specifies an error",
 		body:                errorResp,
@@ -174,7 +174,7 @@ func TestWeekend(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -233,7 +233,7 @@ func TestToday(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -292,7 +292,7 @@ func TestTomorrow(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("https://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -103,7 +103,7 @@ func TestForecast(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}, {
 		desc:                "when the response code is OK but the response body specifies an error",
 		body:                errorResp,
@@ -174,7 +174,7 @@ func TestWeekend(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -233,7 +233,7 @@ func TestToday(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {
@@ -292,7 +292,7 @@ func TestTomorrow(t *testing.T) {
 		body:                resp,
 		code:                500,
 		expectForecastCount: 0,
-		expectError:         errors.New("http://magicseaweed.com/api/fakeKey/forecast/?spot_id=123 returned HTTP status code 500"),
+		expectError:         errors.New("http://magicseaweed.com/api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
 	for _, test := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -119,8 +119,12 @@ func TestForecast(t *testing.T) {
 		expectError:         errors.New("invalid character 'e' looking for beginning of value"),
 	}}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
+
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			server, c := testServerAndClient(test.code, test.body)
 			defer server.Close()
 			forecasts, err := c.Forecast("123")
@@ -178,8 +182,12 @@ func TestWeekend(t *testing.T) {
 		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
+
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			server, c := testServerAndClient(test.code, test.body)
 			defer server.Close()
 			forecasts, err := c.Weekend("123")
@@ -237,8 +245,12 @@ func TestToday(t *testing.T) {
 		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
+
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			server, c := testServerAndClient(test.code, test.body)
 			defer server.Close()
 			forecasts, err := c.Today("123")
@@ -296,8 +308,12 @@ func TestTomorrow(t *testing.T) {
 		expectError:         errors.New("GET /api/<REDACTED>/forecast/?spot_id=123 returned HTTP status code 500"),
 	}}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
+
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
 			server, c := testServerAndClient(test.code, test.body)
 			defer server.Close()
 			forecasts, err := c.Tomorrow("123")

--- a/internal/integrationtest/integration_test.go
+++ b/internal/integrationtest/integration_test.go
@@ -31,6 +31,19 @@ func TestForecast_Integration(t *testing.T) {
 	}
 }
 
+func TestForecast_Integration_error(t *testing.T) {
+	c := seaweed.NewClient("")
+	resp, err := c.Forecast("391")
+	expected := "Unable to authenticate request: Ensure your API key is passed correctly. Refer to the API docs."
+	if err.Error() != expected {
+		t.Errorf("expected Forecast to err with '%s'; got '%s'", expected, err.Error())
+	}
+
+	if len(resp) > 0 {
+		t.Error("erroring Forecast returned forecasts")
+	}
+}
+
 func TestToday_Integration(t *testing.T) {
 	resp, err := client.Today("391")
 	if err != nil {

--- a/internal/integrationtest/integration_test.go
+++ b/internal/integrationtest/integration_test.go
@@ -1,0 +1,93 @@
+package integrationtest
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mdb/seaweed"
+)
+
+var client *seaweed.Client
+
+func TestMain(m *testing.M) {
+	client = seaweed.NewClient(os.Getenv("MAGIC_SEAWEED_API_KEY"))
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+func TestForecast_Integration(t *testing.T) {
+	resp, err := client.Forecast("391")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp) == 0 {
+		t.Error("Forecast returned no forecasts")
+	}
+
+	if resp[0].LocalTimestamp == 0 {
+		t.Error("Forecast returned no forecast timestamp")
+	}
+}
+
+func TestToday_Integration(t *testing.T) {
+	resp, err := client.Today("391")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp) == 0 {
+		t.Error("Today returned no forecasts")
+	}
+
+	today := time.Now().UTC()
+
+	for _, forecast := range resp {
+		fd := time.Unix(forecast.LocalTimestamp, 0).UTC()
+
+		if fd.Day() != today.Day() {
+			t.Errorf("Today returned forecast for '%s'", fd.String())
+		}
+	}
+}
+
+func TestTomorrow_Integration(t *testing.T) {
+	resp, err := client.Tomorrow("391")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp) == 0 {
+		t.Error("API returned no forecasts")
+	}
+
+	tomorrow := time.Now().UTC().AddDate(0, 0, 1)
+
+	for _, forecast := range resp {
+		fd := time.Unix(forecast.LocalTimestamp, 0).UTC()
+
+		if fd.Day() != tomorrow.Day() {
+			t.Errorf("Tomorrow returned forecast for '%s'", fd.String())
+		}
+	}
+}
+
+func TestWeekend_Integration(t *testing.T) {
+	resp, err := client.Weekend("391")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resp) == 0 {
+		t.Error("API returned no forecasts")
+	}
+
+	for _, forecast := range resp {
+		fd := time.Unix(forecast.LocalTimestamp, 0).UTC().Weekday().String()
+
+		if fd != "Saturday" && fd != "Sunday" {
+			t.Errorf("Weekend returned forecast for '%s'", fd)
+		}
+	}
+}

--- a/resources.go
+++ b/resources.go
@@ -2,6 +2,20 @@ package seaweed
 
 import "time"
 
+// APIError represents a Seaweed API error response body.
+//
+// Note that the Magic Seaweed API may respond with an HTTP status code of 200
+// and a response body reporting an error.
+type APIError struct {
+	ErrorResponse ErrorResponse `json:"error_response"`
+}
+
+// ErrorResponse represents a Seaweed API error response.
+type ErrorResponse struct {
+	Code     int    `json:"code"`
+	ErrorMsg string `json:"error_msg"`
+}
+
 // Forecast represents a Seaweed API forecast.
 type Forecast struct {
 	Timestamp      int64     `json:"timestamp"`

--- a/testdata/error.json
+++ b/testdata/error.json
@@ -1,0 +1,6 @@
+{
+  "error_response": {
+    "code": 115,
+    "error_msg": "Unable to authenticate request: Ensure your API key is passed correctly. Refer to the API docs."
+  }
+}


### PR DESCRIPTION
* add integration tests
* handle scenarios where the Magic Seaweed API responds 200, but with an error reported in its response body
* ensure API key is not logged
* use HTTPS
* `client.BaseURL` is now configurable
* improve documentation